### PR TITLE
Add NextSwitch component and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ app.*.map.json
 coverage
 
 .github/
+prompt.txt

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ class MyApp extends StatelessWidget {
               ),
               SizedBox(height: 16),
               
+              // Switch Example
+              NextSwitch(
+                isSelected: true,
+                label: Text('Enable Feature'),
+                onValueChange: (value) {},
+              ),
+              SizedBox(height: 16),
+              
               // Chip Example
               NextChip.solid(
                 child: Text('Success'),
@@ -82,6 +90,7 @@ class MyApp extends StatelessWidget {
 | --------------------- | -------------------------------------------------------- | ----------- |
 | **Button**            | 7 variants, 3 sizes, 6 colors, loading states, icons     | ✅ Complete |
 | **Chip**              | 7 variants, 3 sizes, 6 colors, closable, avatar support  | ✅ Complete |
+| **Switch**            | 3 sizes, 6 colors, label support, icons, disabled states | ✅ Complete |
 | **Checkbox**          | 3 sizes, 6 colors, indeterminate state, validation       | ✅ Complete |
 | **Checkbox Group**    | Multi-selection, validation, orientation control         | ✅ Complete |
 | **Radio Group**       | Single selection, validation, horizontal/vertical layout | ✅ Complete |
@@ -95,7 +104,6 @@ class MyApp extends StatelessWidget {
 | Button Group       | 🔄 Planned |
 | Card               | 🔄 Planned |
 | Input/TextField    | 🔄 Planned |
-| Switch             | 🔄 Planned |
 | Avatar             | 🔄 Planned |
 | Badge              | 🔄 Planned |
 | Modal              | 🔄 Planned |
@@ -168,6 +176,71 @@ NextChip.solid(
 NextChip.dot(
   color: ChipColor.success,
   child: Text('Status'),
+);
+```
+
+### Switch
+
+```dart
+// Basic Switch
+NextSwitch(
+  isSelected: true,
+  onValueChange: (value) => print('Switch: $value'),
+);
+
+// Switch with Label
+NextSwitch(
+  isSelected: false,
+  label: Text('Enable notifications'),
+  onValueChange: (value) {},
+);
+
+// Switch Sizes
+NextSwitch.small(isSelected: true);   // Small
+NextSwitch.medium(isSelected: true);  // Medium (default)
+NextSwitch.large(isSelected: true);   // Large
+
+// Switch Colors
+NextSwitch(
+  color: SwitchColor.primary,
+  isSelected: true,
+  onValueChange: (value) {},
+);
+
+// Switch with Icons
+NextSwitch(
+  isSelected: true,
+  label: Text('Dark Mode'),
+  startContent: Icon(Icons.dark_mode),
+  thumbIcon: Icon(Icons.check, size: 16, color: Colors.white),
+  onValueChange: (value) {},
+);
+
+// Disabled Switch
+NextSwitch(
+  isSelected: true,
+  isDisabled: true,
+  label: Text('Disabled'),
+);
+
+// Read-only Switch
+NextSwitch(
+  isSelected: true,
+  isReadOnly: true,
+  label: Text('Read-only'),
+);
+
+// Controlled Switch
+bool isEnabled = false;
+
+NextSwitch(
+  isSelected: isEnabled,
+  label: Text('Toggle Feature'),
+  onValueChange: (value) {
+    setState(() {
+      isEnabled = value;
+    });
+  },
 );
 ```
 
@@ -256,8 +329,8 @@ flutter run
 
 The example app features:
 
-- **6 Interactive Tabs**: Buttons, Chips, Checkboxes, Radio Groups, Progress,
-  Typography
+- **7 Interactive Tabs**: Buttons, Chips, Switches, Checkboxes, Radio Groups,
+  Progress, Typography
 - **Live Demonstrations**: All variants, sizes, colors, and states
 - **Interactive Controls**: Real-time component customization
 - **Best Practices**: Proper usage patterns and code examples
@@ -317,6 +390,30 @@ Button.solid(color: ButtonColor.secondary);  // Purple
 | `onClose`      | `Function?`   | Close callback   |
 | `startContent` | `Widget?`     | Leading content  |
 | `endContent`   | `Widget?`     | Trailing content |
+
+### NextSwitch
+
+| Property           | Type                  | Description                |
+| ------------------ | --------------------- | -------------------------- |
+| `value`            | `String?`             | Form field value           |
+| `isSelected`       | `bool?`               | Whether switch is selected |
+| `defaultSelected`  | `bool`                | Default selected state     |
+| `onChanged`        | `ValueChanged<bool>?` | Native change callback     |
+| `onValueChange`    | `ValueChanged<bool>?` | Value change callback      |
+| `size`             | `SwitchSize`          | Switch size (sm, md, lg)   |
+| `color`            | `SwitchColor`         | Color theme                |
+| `label`            | `Widget?`             | Label widget               |
+| `startContent`     | `Widget?`             | Leading content widget     |
+| `endContent`       | `Widget?`             | Trailing content widget    |
+| `thumbIcon`        | `Widget?`             | Icon inside thumb          |
+| `isDisabled`       | `bool`                | Disabled state             |
+| `isReadOnly`       | `bool`                | Read-only state            |
+| `disableAnimation` | `bool`                | Disable animations         |
+| `name`             | `String?`             | Form field name            |
+| `autofocus`        | `bool`                | Auto-focus on mount        |
+| `focusNode`        | `FocusNode?`          | Focus node                 |
+| `margin`           | `EdgeInsetsGeometry?` | External margin            |
+| `padding`          | `EdgeInsetsGeometry?` | Internal padding           |
 
 ### NextCheckbox
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,7 +35,7 @@ class _ComponentsDemoPageState extends State<ComponentsDemoPage>
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 6, vsync: this);
+    _tabController = TabController(length: 7, vsync: this);
   }
 
   @override
@@ -81,6 +81,7 @@ class _ComponentsDemoPageState extends State<ComponentsDemoPage>
           tabs: const [
             Tab(text: 'Buttons'),
             Tab(text: 'Chips'),
+            Tab(text: 'Switches'),
             Tab(text: 'Checkboxes'),
             Tab(text: 'Radio Groups'),
             Tab(text: 'Progress'),
@@ -93,6 +94,7 @@ class _ComponentsDemoPageState extends State<ComponentsDemoPage>
         children: [
           _buildButtonsTab(),
           _buildChipsTab(),
+          _buildSwitchesTab(),
           _buildCheckboxTab(),
           _buildRadioTab(),
           _buildProgressTab(),
@@ -295,6 +297,252 @@ class _ComponentsDemoPageState extends State<ComponentsDemoPage>
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildSwitchesTab() {
+    return StatefulBuilder(
+      builder: (context, setState) {
+        bool basicSwitch = false;
+        bool notificationSwitch = true;
+        bool darkModeSwitch = false;
+        bool wifiSwitch = true;
+        bool bluetoothSwitch = false;
+        bool airplaneModeSwitch = false;
+
+        return SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildSection(
+                title: 'Basic Switches',
+                children: [
+                  NextSwitch(
+                    isSelected: basicSwitch,
+                    onValueChange: (value) =>
+                        setState(() => basicSwitch = value),
+                  ),
+                  NextSwitch(
+                    isSelected: true,
+                    label: const Text('Switch with Label'),
+                    onValueChange: (value) {},
+                  ),
+                  const NextSwitch(
+                    isSelected: false,
+                    isDisabled: true,
+                    label: Text('Disabled Switch'),
+                  ),
+                ],
+              ),
+              _buildSection(
+                title: 'Switch Sizes',
+                children: [
+                  NextSwitch.small(
+                    isSelected: true,
+                    label: const Text('Small Switch'),
+                    onValueChange: (value) {},
+                  ),
+                  NextSwitch.medium(
+                    isSelected: true,
+                    label: const Text('Medium Switch'),
+                    onValueChange: (value) {},
+                  ),
+                  NextSwitch.large(
+                    isSelected: true,
+                    label: const Text('Large Switch'),
+                    onValueChange: (value) {},
+                  ),
+                ],
+              ),
+              _buildSection(
+                title: 'Switch Colors',
+                children: [
+                  NextSwitch(
+                    isSelected: true,
+                    color: SwitchColor.primary,
+                    label: const Text('Primary'),
+                    onValueChange: (value) {},
+                  ),
+                  NextSwitch(
+                    isSelected: true,
+                    color: SwitchColor.secondary,
+                    label: const Text('Secondary'),
+                    onValueChange: (value) {},
+                  ),
+                  NextSwitch(
+                    isSelected: true,
+                    color: SwitchColor.success,
+                    label: const Text('Success'),
+                    onValueChange: (value) {},
+                  ),
+                  NextSwitch(
+                    isSelected: true,
+                    color: SwitchColor.warning,
+                    label: const Text('Warning'),
+                    onValueChange: (value) {},
+                  ),
+                  NextSwitch(
+                    isSelected: true,
+                    color: SwitchColor.danger,
+                    label: const Text('Danger'),
+                    onValueChange: (value) {},
+                  ),
+                ],
+              ),
+              _buildSection(
+                title: 'Switches with Icons',
+                children: [
+                  NextSwitch(
+                    isSelected: true,
+                    label: const Text('With Thumb Icon'),
+                    thumbIcon: const Icon(
+                      Icons.check,
+                      size: 16,
+                      color: Colors.white,
+                    ),
+                    onValueChange: (value) {},
+                  ),
+                  NextSwitch(
+                    isSelected: true,
+                    label: const Text('Start & End Content'),
+                    startContent: const Icon(Icons.lightbulb_outline, size: 20),
+                    endContent: const Icon(
+                      Icons.lightbulb,
+                      size: 20,
+                      color: Colors.amber,
+                    ),
+                    onValueChange: (value) {},
+                  ),
+                ],
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Settings Example',
+                      style: Theme.of(context).textTheme.headlineSmall
+                          ?.copyWith(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 16),
+                    Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Column(
+                          children: [
+                            NextSwitch(
+                              isSelected: notificationSwitch,
+                              label: const Text('Push Notifications'),
+                              startContent: const Icon(
+                                Icons.notifications_outlined,
+                              ),
+                              onValueChange: (value) {
+                                setState(() => notificationSwitch = value);
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                    content: Text(
+                                      value
+                                          ? 'Notifications enabled'
+                                          : 'Notifications disabled',
+                                    ),
+                                    duration: const Duration(seconds: 1),
+                                  ),
+                                );
+                              },
+                            ),
+                            const Divider(),
+                            NextSwitch(
+                              isSelected: darkModeSwitch,
+                              label: const Text('Dark Mode'),
+                              startContent: const Icon(
+                                Icons.dark_mode_outlined,
+                              ),
+                              color: SwitchColor.secondary,
+                              onValueChange: (value) =>
+                                  setState(() => darkModeSwitch = value),
+                            ),
+                            const Divider(),
+                            NextSwitch(
+                              isSelected: wifiSwitch,
+                              label: const Text('Wi-Fi'),
+                              startContent: const Icon(Icons.wifi),
+                              color: SwitchColor.success,
+                              onValueChange: (value) =>
+                                  setState(() => wifiSwitch = value),
+                            ),
+                            const Divider(),
+                            NextSwitch(
+                              isSelected: bluetoothSwitch,
+                              label: const Text('Bluetooth'),
+                              startContent: const Icon(Icons.bluetooth),
+                              color: SwitchColor.primary,
+                              onValueChange: (value) =>
+                                  setState(() => bluetoothSwitch = value),
+                            ),
+                            const Divider(),
+                            NextSwitch(
+                              isSelected: airplaneModeSwitch,
+                              label: const Text('Airplane Mode'),
+                              startContent: const Icon(
+                                Icons.airplanemode_active,
+                              ),
+                              color: SwitchColor.warning,
+                              onValueChange: (value) =>
+                                  setState(() => airplaneModeSwitch = value),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Switch States',
+                      style: Theme.of(context).textTheme.headlineSmall
+                          ?.copyWith(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 16),
+                    const NextSwitch(
+                      isSelected: false,
+                      label: Text('Normal Switch (Off)'),
+                    ),
+                    const SizedBox(height: 12),
+                    const NextSwitch(
+                      isSelected: true,
+                      label: Text('Normal Switch (On)'),
+                    ),
+                    const SizedBox(height: 12),
+                    const NextSwitch(
+                      isSelected: false,
+                      isDisabled: true,
+                      label: Text('Disabled Switch (Off)'),
+                    ),
+                    const SizedBox(height: 12),
+                    const NextSwitch(
+                      isSelected: true,
+                      isDisabled: true,
+                      label: Text('Disabled Switch (On)'),
+                    ),
+                    const SizedBox(height: 12),
+                    const NextSwitch(
+                      isSelected: true,
+                      isReadOnly: true,
+                      label: Text('Read-only Switch'),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 

--- a/lib/src/base/enums.dart
+++ b/lib/src/base/enums.dart
@@ -174,3 +174,36 @@ enum SpinnerPlacement {
   /// Spinner at the end
   end,
 }
+
+/// Switch size options
+enum SwitchSize {
+  /// Small switch size
+  sm,
+
+  /// Medium switch size
+  md,
+
+  /// Large switch size
+  lg,
+}
+
+/// Switch color options
+enum SwitchColor {
+  /// Default color
+  defaultColor,
+
+  /// Primary color
+  primary,
+
+  /// Secondary color
+  secondary,
+
+  /// Success color
+  success,
+
+  /// Warning color
+  warning,
+
+  /// Danger color
+  danger,
+}

--- a/lib/src/components/switch.dart
+++ b/lib/src/components/switch.dart
@@ -1,0 +1,415 @@
+import 'package:flutter/material.dart';
+import 'package:next_ui/src/base/enums.dart';
+
+/// A customizable switch component for toggling between states.
+///
+/// Based on HeroUI Switch component design.
+class NextSwitch extends StatefulWidget {
+  /// Creates a switch component.
+  const NextSwitch({
+    super.key,
+    this.value,
+    this.isSelected,
+    this.defaultSelected = false,
+    this.onChanged,
+    this.onValueChange,
+    this.size = SwitchSize.md,
+    this.color = SwitchColor.primary,
+    this.label,
+    this.startContent,
+    this.endContent,
+    this.thumbIcon,
+    this.isDisabled = false,
+    this.isReadOnly = false,
+    this.disableAnimation = false,
+    this.name,
+    this.autofocus = false,
+    this.focusNode,
+    this.margin,
+    this.padding,
+  });
+
+  /// The value of the switch for form handling
+  final String? value;
+
+  /// Whether the switch is selected
+  final bool? isSelected;
+
+  /// Default selected state when uncontrolled
+  final bool defaultSelected;
+
+  /// Called when the switch state changes
+  final ValueChanged<bool>? onChanged;
+
+  /// Called when the switch value changes
+  final ValueChanged<bool>? onValueChange;
+
+  /// Size of the switch
+  final SwitchSize size;
+
+  /// Color theme of the switch
+  final SwitchColor color;
+
+  /// Label widget displayed next to the switch
+  final Widget? label;
+
+  /// Widget displayed at the start of the switch
+  final Widget? startContent;
+
+  /// Widget displayed at the end of the switch
+  final Widget? endContent;
+
+  /// Icon displayed inside the thumb
+  final Widget? thumbIcon;
+
+  /// Whether the switch is disabled
+  final bool isDisabled;
+
+  /// Whether the switch is read-only
+  final bool isReadOnly;
+
+  /// Whether to disable animations
+  final bool disableAnimation;
+
+  /// Form field name
+  final String? name;
+
+  /// Whether to auto-focus the switch
+  final bool autofocus;
+
+  /// Focus node for the switch
+  final FocusNode? focusNode;
+
+  /// External margin
+  final EdgeInsetsGeometry? margin;
+
+  /// Internal padding
+  final EdgeInsetsGeometry? padding;
+
+  @override
+  State<NextSwitch> createState() => _NextSwitchState();
+
+  /// Creates a small switch
+  static NextSwitch small({
+    Key? key,
+    bool? isSelected,
+    bool defaultSelected = false,
+    ValueChanged<bool>? onChanged,
+    ValueChanged<bool>? onValueChange,
+    SwitchColor color = SwitchColor.primary,
+    Widget? label,
+    Widget? startContent,
+    Widget? endContent,
+    Widget? thumbIcon,
+    bool isDisabled = false,
+    bool isReadOnly = false,
+    String? value,
+    String? name,
+    EdgeInsetsGeometry? margin,
+    EdgeInsetsGeometry? padding,
+  }) {
+    return NextSwitch(
+      key: key,
+      isSelected: isSelected,
+      defaultSelected: defaultSelected,
+      onChanged: onChanged,
+      onValueChange: onValueChange,
+      size: SwitchSize.sm,
+      color: color,
+      label: label,
+      startContent: startContent,
+      endContent: endContent,
+      thumbIcon: thumbIcon,
+      isDisabled: isDisabled,
+      isReadOnly: isReadOnly,
+      value: value,
+      name: name,
+      margin: margin,
+      padding: padding,
+    );
+  }
+
+  /// Creates a medium switch (default)
+  static NextSwitch medium({
+    Key? key,
+    bool? isSelected,
+    bool defaultSelected = false,
+    ValueChanged<bool>? onChanged,
+    ValueChanged<bool>? onValueChange,
+    SwitchColor color = SwitchColor.primary,
+    Widget? label,
+    Widget? startContent,
+    Widget? endContent,
+    Widget? thumbIcon,
+    bool isDisabled = false,
+    bool isReadOnly = false,
+    String? value,
+    String? name,
+    EdgeInsetsGeometry? margin,
+    EdgeInsetsGeometry? padding,
+  }) {
+    return NextSwitch(
+      key: key,
+      isSelected: isSelected,
+      defaultSelected: defaultSelected,
+      onChanged: onChanged,
+      onValueChange: onValueChange,
+      color: color,
+      label: label,
+      startContent: startContent,
+      endContent: endContent,
+      thumbIcon: thumbIcon,
+      isDisabled: isDisabled,
+      isReadOnly: isReadOnly,
+      value: value,
+      name: name,
+      margin: margin,
+      padding: padding,
+    );
+  }
+
+  /// Creates a large switch
+  static NextSwitch large({
+    Key? key,
+    bool? isSelected,
+    bool defaultSelected = false,
+    ValueChanged<bool>? onChanged,
+    ValueChanged<bool>? onValueChange,
+    SwitchColor color = SwitchColor.primary,
+    Widget? label,
+    Widget? startContent,
+    Widget? endContent,
+    Widget? thumbIcon,
+    bool isDisabled = false,
+    bool isReadOnly = false,
+    String? value,
+    String? name,
+    EdgeInsetsGeometry? margin,
+    EdgeInsetsGeometry? padding,
+  }) {
+    return NextSwitch(
+      key: key,
+      isSelected: isSelected,
+      defaultSelected: defaultSelected,
+      onChanged: onChanged,
+      onValueChange: onValueChange,
+      size: SwitchSize.lg,
+      color: color,
+      label: label,
+      startContent: startContent,
+      endContent: endContent,
+      thumbIcon: thumbIcon,
+      isDisabled: isDisabled,
+      isReadOnly: isReadOnly,
+      value: value,
+      name: name,
+      margin: margin,
+      padding: padding,
+    );
+  }
+}
+
+class _NextSwitchState extends State<NextSwitch> {
+  late bool _isSelected;
+  late FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _isSelected = widget.isSelected ?? widget.defaultSelected;
+    _focusNode = widget.focusNode ?? FocusNode();
+  }
+
+  @override
+  void didUpdateWidget(NextSwitch oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.isSelected != null && widget.isSelected != _isSelected) {
+      _isSelected = widget.isSelected!;
+    }
+  }
+
+  @override
+  void dispose() {
+    if (widget.focusNode == null) _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _handleChanged(bool value) {
+    if (widget.isDisabled || widget.isReadOnly) return;
+
+    setState(() {
+      _isSelected = value;
+    });
+
+    widget.onChanged?.call(value);
+    widget.onValueChange?.call(value);
+  }
+
+  Color _getActiveColor(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    switch (widget.color) {
+      case SwitchColor.defaultColor:
+        return colorScheme.outline;
+      case SwitchColor.primary:
+        return colorScheme.primary;
+      case SwitchColor.secondary:
+        return colorScheme.secondary;
+      case SwitchColor.success:
+        return Colors.green;
+      case SwitchColor.warning:
+        return Colors.orange;
+      case SwitchColor.danger:
+        return colorScheme.error;
+    }
+  }
+
+  double _getSwitchScale() {
+    switch (widget.size) {
+      case SwitchSize.sm:
+        return 0.8;
+      case SwitchSize.md:
+        return 1;
+      case SwitchSize.lg:
+        return 1.2;
+    }
+  }
+
+  EdgeInsetsGeometry _getContentPadding() {
+    switch (widget.size) {
+      case SwitchSize.sm:
+        return const EdgeInsets.all(4);
+      case SwitchSize.md:
+        return const EdgeInsets.all(6);
+      case SwitchSize.lg:
+        return const EdgeInsets.all(8);
+    }
+  }
+
+  Widget _buildSwitch(BuildContext context) {
+    final activeColor = _getActiveColor(context);
+    final switchScale = _getSwitchScale();
+
+    Widget switchWidget = Transform.scale(
+      scale: switchScale,
+      child: Switch(
+        value: _isSelected,
+        onChanged:
+            widget.isDisabled || widget.isReadOnly ? null : _handleChanged,
+        activeColor: activeColor,
+        activeTrackColor: activeColor.withValues(alpha: 0.5),
+        inactiveThumbColor: Theme.of(context).colorScheme.outline,
+        inactiveTrackColor:
+            Theme.of(context).colorScheme.surfaceContainerHighest,
+        focusNode: _focusNode,
+        autofocus: widget.autofocus,
+        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      ),
+    );
+
+    // Add thumb icon if provided
+    if (widget.thumbIcon != null) {
+      switchWidget = Stack(
+        alignment: Alignment.center,
+        children: [
+          switchWidget,
+          if (_isSelected)
+            Positioned(
+              right: switchScale * 4,
+              child: IgnorePointer(
+                child: Transform.scale(
+                  scale: switchScale * 0.6,
+                  child: widget.thumbIcon,
+                ),
+              ),
+            )
+          else
+            Positioned(
+              left: switchScale * 4,
+              child: IgnorePointer(
+                child: Transform.scale(
+                  scale: switchScale * 0.6,
+                  child: widget.thumbIcon,
+                ),
+              ),
+            ),
+        ],
+      );
+    }
+
+    return switchWidget;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final switch_ = _buildSwitch(context);
+
+    // If no additional content, return just the switch
+    if (widget.label == null &&
+        widget.startContent == null &&
+        widget.endContent == null) {
+      return Container(
+        margin: widget.margin,
+        padding: widget.padding,
+        child: switch_,
+      );
+    }
+
+    // Build complete switch with content
+    final children = <Widget>[];
+
+    // Add start content
+    if (widget.startContent != null) {
+      children
+        ..add(widget.startContent!)
+        ..add(SizedBox(width: _getContentPadding().horizontal / 2));
+    }
+
+    // Add the switch
+    children.add(switch_);
+
+    // Add spacing if there's a label or end content
+    if (widget.label != null || widget.endContent != null) {
+      children.add(SizedBox(width: _getContentPadding().horizontal / 2));
+    }
+
+    // Add label
+    if (widget.label != null) {
+      children.add(
+        Expanded(
+          child: GestureDetector(
+            onTap: widget.isDisabled || widget.isReadOnly
+                ? null
+                : () => _handleChanged(!_isSelected),
+            child: DefaultTextStyle(
+              style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                    color: widget.isDisabled
+                        ? Theme.of(context).disabledColor
+                        : null,
+                  ),
+              child: widget.label!,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Add end content
+    if (widget.endContent != null) {
+      if (widget.label == null) {
+        children.add(SizedBox(width: _getContentPadding().horizontal / 2));
+      }
+      children.add(widget.endContent!);
+    }
+
+    return Container(
+      margin: widget.margin,
+      padding: widget.padding ?? _getContentPadding(),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: children,
+      ),
+    );
+  }
+}

--- a/lib/src/index.dart
+++ b/lib/src/index.dart
@@ -7,4 +7,5 @@ export 'package:next_ui/src/components/checkbox_group.dart';
 export 'package:next_ui/src/components/chip.dart';
 export 'package:next_ui/src/components/circular_progress.dart';
 export 'package:next_ui/src/components/radio_group.dart';
+export 'package:next_ui/src/components/switch.dart';
 export 'package:next_ui/src/components/text.dart';

--- a/test/src/switch_test.dart
+++ b/test/src/switch_test.dart
@@ -1,0 +1,328 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:next_ui/next_ui.dart';
+
+void main() {
+  group('NextSwitch', () {
+    testWidgets('renders basic switch with default values', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: NextSwitch(
+              onValueChange: (value) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(Switch), findsOneWidget);
+
+      final switch_ = tester.widget<Switch>(find.byType(Switch));
+      expect(switch_.value, false); // default value
+    });
+
+    testWidgets('handles initial selected state', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: NextSwitch(
+              isSelected: true,
+              onValueChange: (value) {},
+            ),
+          ),
+        ),
+      );
+
+      final switch_ = tester.widget<Switch>(find.byType(Switch));
+      expect(switch_.value, true);
+    });
+
+    testWidgets('handles switch tap and triggers callbacks', (tester) async {
+      var switchValue = false;
+      var onChangedCalled = false;
+      var onValueChangeCalled = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: NextSwitch(
+              isSelected: switchValue,
+              onChanged: (value) {
+                onChangedCalled = true;
+                switchValue = value;
+              },
+              onValueChange: (value) {
+                onValueChangeCalled = true;
+                switchValue = value;
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(Switch), findsOneWidget);
+
+      // Initially off
+      final switch_ = tester.widget<Switch>(find.byType(Switch));
+      expect(switch_.value, false);
+
+      // Tap the switch
+      await tester.tap(find.byType(Switch));
+      await tester.pump();
+
+      expect(onChangedCalled, true);
+      expect(onValueChangeCalled, true);
+    });
+
+    testWidgets('renders label when provided', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: NextSwitch(
+              label: const Text('Test Label'),
+              onValueChange: (value) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Test Label'), findsOneWidget);
+      expect(find.byType(Switch), findsOneWidget);
+    });
+
+    testWidgets('renders start and end content', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: NextSwitch(
+              startContent: const Icon(Icons.lightbulb_outline),
+              endContent: const Icon(Icons.lightbulb),
+              onValueChange: (value) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.lightbulb_outline), findsOneWidget);
+      expect(find.byIcon(Icons.lightbulb), findsOneWidget);
+      expect(find.byType(Switch), findsOneWidget);
+    });
+
+    testWidgets('disabled switch does not respond to taps', (tester) async {
+      var switchValue = false;
+      var callbackCalled = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: NextSwitch(
+              isSelected: switchValue,
+              isDisabled: true,
+              onValueChange: (value) {
+                callbackCalled = true;
+                switchValue = value;
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Try to tap the disabled switch
+      await tester.tap(find.byType(Switch));
+      await tester.pump();
+
+      expect(callbackCalled, false);
+      expect(switchValue, false);
+
+      final switch_ = tester.widget<Switch>(find.byType(Switch));
+      expect(switch_.onChanged, isNull); // Should be null when disabled
+    });
+
+    testWidgets('read-only switch does not respond to taps', (tester) async {
+      var switchValue = true;
+      var callbackCalled = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: NextSwitch(
+              isSelected: switchValue,
+              isReadOnly: true,
+              onValueChange: (value) {
+                callbackCalled = true;
+                switchValue = value;
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Try to tap the read-only switch
+      await tester.tap(find.byType(Switch));
+      await tester.pump();
+
+      expect(callbackCalled, false);
+      expect(switchValue, true);
+    });
+
+    testWidgets('tapping label toggles switch when not disabled',
+        (tester) async {
+      var switchValue = false;
+      var callbackCalled = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: NextSwitch(
+              isSelected: switchValue,
+              label: const Text('Toggle me'),
+              onValueChange: (value) {
+                callbackCalled = true;
+                switchValue = value;
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Tap the label
+      await tester.tap(find.text('Toggle me'));
+      await tester.pump();
+
+      expect(callbackCalled, true);
+    });
+
+    group('Static constructors', () {
+      testWidgets('small switch constructor works', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: NextSwitch.small(
+                isSelected: true,
+                label: const Text('Small Switch'),
+                onValueChange: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(NextSwitch), findsOneWidget);
+        expect(find.byType(Switch), findsOneWidget);
+        expect(find.text('Small Switch'), findsOneWidget);
+      });
+
+      testWidgets('medium switch constructor works', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: NextSwitch.medium(
+                isSelected: true,
+                label: const Text('Medium Switch'),
+                onValueChange: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(NextSwitch), findsOneWidget);
+        expect(find.byType(Switch), findsOneWidget);
+        expect(find.text('Medium Switch'), findsOneWidget);
+      });
+
+      testWidgets('large switch constructor works', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: NextSwitch.large(
+                isSelected: true,
+                label: const Text('Large Switch'),
+                onValueChange: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(NextSwitch), findsOneWidget);
+        expect(find.byType(Switch), findsOneWidget);
+        expect(find.text('Large Switch'), findsOneWidget);
+      });
+    });
+
+    group('Switch colors', () {
+      testWidgets('applies correct color theme', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: NextSwitch(
+                isSelected: true,
+                color: SwitchColor.success,
+                onValueChange: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final switch_ = tester.widget<Switch>(find.byType(Switch));
+        expect(
+          switch_.activeColor,
+          Colors.green,
+        ); // Success color should be green
+      });
+    });
+
+    group('Controlled vs Uncontrolled', () {
+      testWidgets('works as controlled component', (tester) async {
+        var externalValue = false;
+
+        await tester.pumpWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return MaterialApp(
+                home: Scaffold(
+                  body: NextSwitch(
+                    isSelected: externalValue,
+                    onValueChange: (value) {
+                      setState(() {
+                        externalValue = value;
+                      });
+                    },
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+
+        // Initially false
+        var switch_ = tester.widget<Switch>(find.byType(Switch));
+        expect(switch_.value, false);
+
+        // Tap to change
+        await tester.tap(find.byType(Switch));
+        await tester.pump();
+
+        // Should now be true
+        switch_ = tester.widget<Switch>(find.byType(Switch));
+        expect(switch_.value, true);
+        expect(externalValue, true);
+      });
+
+      testWidgets('works as uncontrolled component with default value',
+          (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: NextSwitch(
+                defaultSelected: true,
+                onValueChange: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final switch_ = tester.widget<Switch>(find.byType(Switch));
+        expect(switch_.value, true); // Should use default value
+      });
+    });
+  });
+}


### PR DESCRIPTION
- Introduced `NextSwitch` component with customizable options including size, color, and content.
- Added `SwitchSize` and `SwitchColor` enums to `enums.dart` for switch properties.
- Updated `index.dart` to export the new `switch.dart` file.
- Enhanced `README.md` with detailed examples and marked `Switch` as completed in the documentation.
- Updated `.gitignore` to include `prompt.txt` and ensure proper file management.